### PR TITLE
Ajoute des exemples de calcul d'APL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # CHANGELOG
 
+### 0.0.1 [#2](https://github.com/betagouv/aides-calculatrice-back/pull/2)
+
+* Ajouts sans impact sur la réutilisation de l'API web.
+* Détail : 
+  * Ajoute des requêtes types de calcul et de debug d'`APL` (aide personnalisée au logement) dans `payloads/`
+  * Ajoute un `Makefile` avec cibles d'installation et d'exécution de l'API web ainsi que des cibles de calcul d'APL
+  * Initialise une documentation des modalités de contribution dans `CONTRIBUTING.md`
+
 # 0.0.0 [#1](https://github.com/betagouv/aides-calculatrice-back/pull/1)
 
 * Évolutions techniques et ajout de fonctionnalité
 * Détail : 
-  * Initialisation d'une configuration Python avec Poetry (`pyproject.toml`)
+  * Initialisation d'une configuration Python avec Poetry (`pyproject.toml`).
   * Initialisation de dépendances pour exécution d'une API web openfisca-france.
   * Documentation de l'installation d'un environnement Python et de l'exécution de l'API web.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contribuer à aides-calculatrice-back
+
+Merci de votre volonté de contribuer au dépôt `aides-calculatrice-back` 🙂
+
+Afin de faciliter cette contribution et d'améliorer la qualité du code, ce fichier décrit des règles d'usage structurantes.
+
+## Description des évolutions
+
+Les évolutions de `aides-calculatrice-back` doivent être compréhensibles pour des utilisateurs ne disposant pas du contexte complet de l'application. 
+
+C'est pourquoi nous faisons le choix d'un versionnement distinguant les modifications non rétro-compatibles pour les utilisateurs, des évolutions intermédiaires ou mineures. Et d'une documentation des modifications dans un CHANGELOG.
+
+### Versionnement des évolutions
+
+Le mode de versionnement choisi est un [versionnement sémantique](https://semver.org/lang/fr/) de l'application où l'évaluation des changements majeurs se fait au regard des évolutions de l'API web.
+
+La version est à mettre à jour dans le fichier `pyproject.toml`.
+
+### CHANGELOG
+
+La documentation des évolutions quel qu'en soit la nature est à mettre à jour avant chaque merge sur la branche `main` dans un fichier `CHANGELOG.md`, rédigé en français. 
+
+Cette documentation doit être explicite, indiquer la Pull request d'origine et dans la mesure du possible décrire les changements du point de vue de l'impact pour l'usager du dépôt.
+
+Un chapitre ou sous-chapitre décrit l'évolution apportée par une Pull request : 
+* Un chapitre de premier niveau `#` décrit une évolution de version majeure (changement non rétro-compatible), 
+* `##` décrit une évolution intermédiaire (comme l'ajout d'une fonctionnalité) 
+* et `###` décrit une évolution de type patch (comme une mise à jour technique sans impact métier ou nécessité de migration de code pour les usagers de l'API web).

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
+
+GREEN = '\033[0;32m'
+COLOR_OFF = '\033[0m'
+POETRY_CURRENT_ENV_PATH := $(shell poetry env info -p)
+
 all: install api
 
 install:
+	@echo $(GREEN)"Using virtualenv: "$(POETRY_CURRENT_ENV_PATH)$(COLOR_OFF)
 	poetry install --no-root
 
 api:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+all: install api
+
+install:
+	poetry install --no-root
+
+api:
+	poetry run openfisca serve --country-package openfisca_france
+
+apl:
+	curl -X POST http://127.0.0.1:5000/calculate -H 'Content-Type: application/json' -d @payloads/apl.json | jq

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-
-GREEN = '\033[0;32m'
-COLOR_OFF = '\033[0m'
+GREEN := '\033[0;32m'
+COLOR_OFF := '\033[0m'
 POETRY_CURRENT_ENV_PATH := $(shell poetry env info -p)
+
 
 all: install api
 
@@ -16,3 +16,6 @@ api:
 
 apl:
 	curl -X POST http://127.0.0.1:5000/calculate -H 'Content-Type: application/json' -d @payloads/apl.json | jq
+
+apl+d:
+	curl -X POST http://127.0.0.1:5000/calculate -H 'Content-Type: application/json' -d @payloads/apl_debug.json | jq

--- a/payloads/apl.json
+++ b/payloads/apl.json
@@ -59,6 +59,9 @@
             "coloc": {
                 "2025-01": false
             },
+            "logement_conventionne": {
+                "2025-01": true
+            },
             "zone_apl": {
                 "2025-01": null
             }

--- a/payloads/apl.json
+++ b/payloads/apl.json
@@ -1,0 +1,56 @@
+{
+    "individus": {
+        "Camille": {},
+        "Claude": {
+            "salaire_de_base": {
+                "2025-01": 1801.80
+            }
+        },
+        "Dominique": {
+            "salaire_de_base": {
+                "2025-01": 1801.80
+            }
+        }
+    },
+    "foyers_fiscaux": {
+        "foyer_fiscal_1": {
+            "declarants": [
+                "Claude",
+                "Dominique"
+            ],
+            "personnes_a_charge": [
+                "Camille"
+            ]
+        }
+    },
+    "menages": {
+        "menage_1": {
+            "conjoint": [
+                "Dominique"
+            ],
+            "enfants": [
+                "Camille"
+            ],
+            "personne_de_reference": [
+                "Claude"
+            ],
+            "revenu_disponible": {
+                "2025": null
+            }
+        }
+    },
+    "familles": {
+        "famille_1": {
+            "enfants": [
+                "Camille"
+            ],
+            "parents": [
+                "Claude",
+                "Dominique"
+            ],
+            "apl": {
+                "2025-01": null
+            }
+        }
+    }
+}

--- a/payloads/apl_debug.json
+++ b/payloads/apl_debug.json
@@ -59,6 +59,15 @@
             "coloc": {
                 "2025-01": false
             },
+            "logement_conventionne": {
+                "2025-01": null
+            },
+            "logement_crous": {
+                "2025-01": false
+            },
+            "logement_chambre": {
+                "2025-01": null
+            },
             "zone_apl": {
                 "2025-01": null
             }
@@ -73,10 +82,16 @@
                 "Claude",
                 "Dominique"
             ],
+            "reduction_loyer_solidarite_plafond_ressources": {
+                "2025-01": null
+            },
             "reduction_loyer_solidarite": {
                 "2025-01": null
             },
             "aide_logement_base_ressources": {
+                "2025-01": null
+            },
+            "aide_logement_montant_brut": {
                 "2025-01": null
             },
             "apl": {

--- a/payloads/apl_debug.json
+++ b/payloads/apl_debug.json
@@ -60,7 +60,7 @@
                 "2025-01": false
             },
             "logement_conventionne": {
-                "2025-01": null
+                "2025-01": true
             },
             "logement_crous": {
                 "2025-01": false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aides-calculatrice-back"
-version = "0.0.0"
+version = "0.0.1"
 description = "Le dorsal d'aides-simplifiées"
 authors = ["Aides Simplifiées <aides.simplifiees@numerique.gouv.fr>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Connecté à https://github.com/betagouv/aides-simulateur-front/issues/3

* Ajout de fonctionnalités.
* Détail : 
  * Ajoute des requêtes types de calcul et de debug d'`APL` (aide personnalisée au logement) dans `payloads/`
  * Ajoute un `Makefile` avec cibles d'installation et d'exécution de l'API web ainsi que des cibles de calcul d'APL
  * Initialise une documentation des modalités de contribution dans `CONTRIBUTING.md`