### PR TITLE
Allonge la durée de réponse au client de 60 secondes à 120 par sécurité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # CHANGELOG
 
+### 0.0.3 [#4](https://github.com/betagouv/aides-calculatrice-back/pull/4)
+
+* Évolution technique.
+* Détail :
+  * Allonge la durée de timeout par défaut à l'exécution par `Procfile`
+  * Permet de limiter le risque d'erreur `504` en passant de 60s. à 120s. de temps alloué
+
 ### 0.0.2 [#3](https://github.com/betagouv/aides-calculatrice-back/pull/3)
 
 * Évolutions techniques.
 * Détail : 
   * Ajoute la configuration pour le déploiement sur Scalingo
     * Ajoute `.python-version` définissant la version de Python par défaut pour le Python buildpack de Scalingo
-    * Ajoute la commande d'exécution de l'API web dans `Procfile` utilisant $PORT de Scalingo
+    * Ajoute la commande d'exécution de l'API web dans `Procfile` utilisant `$PORT` de Scalingo
     * Anticipe la création du module `aides_calculatrice_back` pour la bonne exécution du `poetry install` appelé par défaut par Scalingo
 
 ### 0.0.1 [#2](https://github.com/betagouv/aides-calculatrice-back/pull/2)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: openfisca serve --country-package openfisca_france --bind 0.0.0.0:$PORT
+web: openfisca serve --country-package openfisca_france --bind 0.0.0.0:$PORT --timeout 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aides-calculatrice-back"
-version = "0.0.2"
+version = "0.0.3"
 description = "Le dorsal d'aides-simplifiées"
 authors = ["Aides Simplifiées <aides.simplifiees@numerique.gouv.fr>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
* Évolution technique.
* Détail :
  * Allonge la durée de timeout par défaut à l'exécution par `Procfile`
  * Permet de limiter le risque d'erreur `504` en passant de 60s. à 120s. de temps alloué

- - - -
Documentation consultée : https://doc.scalingo.com/platform/internals/routing